### PR TITLE
feat: add Streamlit OAuth agent workflow and refresh consent UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,4 +221,4 @@ tls
 uploads
 db
 *.log
-*.xlsm
+agent/.app*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,11 +49,13 @@
       "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/.venv/bin/streamlit",
-      "args": ["run", "agent/agent.py"],
+      "args": ["run", "agent/agent.py", "--server.port", "9090"],
       "console": "integratedTerminal",
       "justMyCode": false,
       "env": {
-        "DOPPLER_ENV": "1"
+        "DOPPLER_ENV": "1",
+        "DOPPLER_CONFIG": "dev_agent",
+        "PYTHONPATH": ".:${workspaceFolder}"
       }
     },
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,6 @@
       "console": "integratedTerminal",
       "django": true,
       "justMyCode": false,
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
         "DOPPLER_ENV": "1"
@@ -25,7 +24,6 @@
       "console": "integratedTerminal",
       "django": true,
       "justMyCode": false,
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "DOPPLER_ENV": "1"
       }
@@ -39,7 +37,6 @@
       "console": "integratedTerminal",
       "django": true,
       "justMyCode": false,
-      "envFile": "${workspaceFolder}/.env",
       "env": {
         "DOPPLER_ENV": "1"
       }
@@ -50,12 +47,13 @@
       "request": "launch",
       "program": "${workspaceFolder}/.venv/bin/streamlit",
       "args": ["run", "agent/agent.py", "--server.port", "9090"],
+      "cwd": "${workspaceFolder}",
       "console": "integratedTerminal",
       "justMyCode": false,
       "env": {
         "DOPPLER_ENV": "1",
         "DOPPLER_CONFIG": "dev_agent",
-        "PYTHONPATH": ".:${workspaceFolder}"
+        "PYTHONPATH": "."
       }
     },
   ]

--- a/agent/.app_data.json
+++ b/agent/.app_data.json
@@ -1,6 +1,0 @@
-{
-    "oauth_access_token": "hx5lKQD7gUczjNfcLXf9zlvh5ycQXe",
-    "oauth_client_id": "xqwcYT7SB6lrUIElPyvn7ww8s577UTUCRRmwTTKN",
-    "oauth_refresh_token": "YuPL0vJf0rqSOcJZCdZRhKMCx3OtMr"
-}
-   

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -1,29 +1,54 @@
 import asyncio
 import json
 import os
+import secrets
+import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional
+from urllib.parse import urlencode
 
+import httpx
 import logfire
-import requests
 import streamlit as st
 from dotenv import load_dotenv
 from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPServerStreamableHTTP
 from pydantic_ai.messages import (
     BuiltinToolCallPart,
     BuiltinToolReturnPart,
     ModelMessage,
+    ModelRequest,
     ModelResponse,
+    RetryPromptPart,
     ToolCallPart,
     ToolReturnPart,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
-    from pydantic_ai.toolsets import AbstractToolset
+    pass
 
 # Build paths inside the project like this: BASE_DIR / "subdir".
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+for bogus in ["agent", "agent/agent.py"]:
+    try:
+        sys.path.remove(bogus)
+    except ValueError:
+        pass
+
+if __package__ in {None, ""}:
+    __package__ = "agent"
+
+from .oauth import (  # noqa: E402
+    build_pkce_challenge,
+    discover_oauth_metadata,
+    exchange_code_for_tokens,
+    generate_pkce_pair,
+)
 
 # ------------------------
 # Streamlit + Agent configuration
@@ -39,79 +64,71 @@ else:
     load_dotenv()
 
 
-# ------------------------
-# OAuth2 Config (replace with real values)
-# ------------------------
-OAUTH_SERVER = "http://localhost:8080/.well-known/oauth-authorization-server"
-AUTH_URL = "https://auth.example.com/authorize"
-TOKEN_URL = "https://auth.example.com/token"
-CLIENT_ID = "my-client-id"
-CLIENT_SECRET = "my-client-secret"
-REDIRECT_URI = "http://localhost:8501"  # must match app URL
+def truncate(text: str, length: int) -> str:
+    return text if len(text) <= length else text[: length - 3] + "..."
 
+
+MODEL_RESPONSE_SPINNER = """
+<style>
+.model-response-spinner{display:flex;align-items:center;gap:0.5rem;font-size:0.9rem;}
+.model-response-spinner__dots{display:flex;gap:0.3rem;}
+.model-response-spinner__dot{width:0.6rem;height:0.6rem;border-radius:50%;background:#ffffff;opacity:0.4;
+    animation:model-response-spinner-bounce 1s infinite ease-in-out;}
+.model-response-spinner__dot:nth-child(2){animation-delay:0.1s;}
+.model-response-spinner__dot:nth-child(3){animation-delay:0.2s;}
+@keyframes model-response-spinner-bounce{0%,80%,100%{transform:scale(0.6);opacity:0.3;}
+    40%{transform:scale(1);opacity:1;}}
+</style>
+<div class="model-response-spinner">
+  <div class="model-response-spinner__dots">
+    <div class="model-response-spinner__dot"></div>
+    <div class="model-response-spinner__dot"></div>
+    <div class="model-response-spinner__dot"></div>
+  </div>
+
+  <span>Model is thinking…</span>
+</div>
+"""
+
+
+# OAUTH
+OAUTH_SERVER = "http://localhost:8080/.well-known/oauth-authorization-server"
+REGISTER_FALLBACK_URL = "http://localhost:8080/oauth-apps/register"
+REDIRECT_URI = "http://localhost:8501"  # must match app URL
+OAUTH_SCOPE = "read write"
+
+# AGENT
+SYSTEM_PROMPT = os.environ.get("SYSTEM_PROMPT", "You are a helpful assistant. Use tools if needed.")
+MODEL_NAME = os.environ["OPENAI_MODEL"]
+API_KEY = os.environ["OPENAI_API_KEY"]
+os.environ["OPENAI_API_KEY"] = os.environ["OPENAI_API_KEY"]
+
+# MCP
+MCP_SERVER_URL = os.environ["MCP_URL"]
+MCP_AUTH_KEY = os.environ.get("MCP_AUTH_KEY")
+MCP_AUTH_VALUE_PREFIX = os.environ.get("MCP_AUTH_VALUE_PREFIX", "")
 
 if os.getenv("LOGFIRE_TOKEN"):
     logfire.configure(token=os.getenv("LOGFIRE_TOKEN"), scrubbing=False)
     logfire.instrument_pydantic_ai()
 
 
-# ------------------------
-# Build agent with tool
-# ------------------------
-def build_agent(
-    model_name: str,
-    *,
-    toolsets: Sequence["AbstractToolset[Any]"] | None = None,
-) -> Agent:
-    """Instantiate the Pydantic agent with the mock MCP tool."""
-
-    return Agent(
-        model=model_name,
-        toolsets=tuple(toolsets or ()),
-        system_prompt="You are a helpful assistant. Use tools if needed.",
-    )
-
-
-def load_agent_settings() -> Dict[str, Any]:
-    """Resolve agent configuration from required environment variables."""
-
-    model_name = os.environ["OPENAI_MODEL"]
-    api_key = os.environ["OPENAI_API_KEY"]
-
-    # Ensure downstream OpenAI-compatible clients read the resolved key.
-    os.environ["OPENAI_API_KEY"] = api_key
-
-    app_data_obj = st.session_state.get("app_data")
-    app_data_dict = asdict(app_data_obj) if isinstance(app_data_obj, AppData) else {}
-    mcp_toolsets, mcp_meta = load_mcp_toolsets(app_data_obj if isinstance(app_data_obj, AppData) else None)
-
-    return {
-        "model": model_name,
-        "api_key": api_key,
-        "toolsets": mcp_toolsets,
-        "mcp_meta": mcp_meta,
-        "app_data": app_data_dict,
-    }
-
-
 @dataclass
 class AppData:
-    oauth_client_id: Optional[str] = None
+    oauth_client_id: str = None
     oauth_access_token: Optional[str] = None
     oauth_refresh_token: Optional[str] = None
 
 
 class AppDataManager:
-    """Persistence helpers for OAuth client/token state."""
-
     path: ClassVar[Path] = APP_DATA_FILE
 
     @classmethod
-    def load(cls) -> AppData:
+    def load(cls) -> AppData | None:
         try:
             raw = cls.path.read_text(encoding="utf-8")
         except FileNotFoundError:
-            return AppData()
+            return None
 
         try:
             data = json.loads(raw)
@@ -124,7 +141,7 @@ class AppDataManager:
         except json.JSONDecodeError:
             pass
 
-        return AppData()
+        return None
 
     @classmethod
     def save(cls, data: AppData) -> None:
@@ -152,90 +169,139 @@ class AppDataManager:
         return updated
 
 
-def load_mcp_toolsets(app_data: AppData | None) -> tuple[list["AbstractToolset[Any]"], Dict[str, Any]]:
-    """Instantiate the streamable HTTP MCP toolset from required env vars."""
+def extract_tool_activity(messages: List[ModelMessage]) -> tuple[List[str], bool]:
+    """Return activity entries plus whether any tool call was observed."""
 
-    try:
-        from pydantic_ai.mcp import MCPServerStreamableHTTP
-    except ImportError as exc:  # pragma: no cover - optional dependency missing
-        raise RuntimeError("MCP extras are required but missing. Install pydantic-ai with MCP support.") from exc
+    def format_payload(value: Any, *, max_chars: int = 2000) -> tuple[str, str]:
+        """Return a clipped string representation and a suggested language for code blocks."""
 
-    url = os.environ["MCP_URL"].strip()
-    if not url:
-        raise ValueError("MCP_URL cannot be empty")
+        if value is None:
+            return "null", "text"
 
-    token = (app_data.oauth_access_token if app_data else None) or ""
-    if not token:
-        raise ValueError("MCP OAuth access token missing from app data")
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return "", "text"
+            try:
+                parsed = json.loads(stripped)
+            except ValueError:
+                text = stripped
+                language = "text"
+            else:
+                text = json.dumps(parsed, ensure_ascii=False, indent=2, default=str)
+                language = "json"
+        else:
+            text = json.dumps(value, ensure_ascii=False, indent=2, default=str)
+            language = "json"
 
-    headers = {"Authorization": f"Bearer {token}"}
-    toolset = MCPServerStreamableHTTP(url=url, headers=headers)
+        if len(text) > max_chars:
+            text = text[: max_chars - 3] + "..."
 
-    meta = {
-        "method": "http",
-        "status": "ready",
-        "detail": url,
-        "token_present": True,
-    }
+        return text, language
 
-    return [toolset], meta
+    def payload_block(value: Any) -> str:
+        text, language = format_payload(value)
+        if not text:
+            return ""
+        return f"```{language}\n{text}\n```"
 
+    context_activity: List[str] = []
+    tool_activity: List[str] = []
+    post_call_activity: List[str] = []
+    tool_call_detected = False
 
-def extract_tool_activity(messages: List[ModelMessage]) -> List[str]:
-    """Return human-readable descriptions of tool activity from model messages."""
-
-    activity: List[str] = []
     for message in messages:
+        if isinstance(message, ModelRequest):
+            if message.instructions:
+                block = payload_block(message.instructions)
+                label = "📨 Model request instructions"
+                context_activity.append(f"{label}\n\n{block}" if block else label)
+
+            for part in message.parts:
+                if isinstance(part, (ToolReturnPart, BuiltinToolReturnPart)):
+                    tool_call_detected = True
+                    block = payload_block(part.content)
+                    label = f"📤 Tool return to model • `{part.tool_name}`"
+                    post_call_activity.append(f"{label}\n\n{block}" if block else label)
+                elif isinstance(part, RetryPromptPart):
+                    tool_call_detected = True
+                    block = payload_block(part.content)
+                    base = "🔁 Retry prompt"
+                    if part.tool_name:
+                        base += f" • `{part.tool_name}`"
+                    post_call_activity.append(f"{base}\n\n{block}" if block else base)
+
+            continue
+
         if not isinstance(message, ModelResponse):
             continue
 
         for part in message.parts:
             if isinstance(part, (ToolCallPart, BuiltinToolCallPart)):
-                args = json.dumps(part.args, ensure_ascii=False) if part.args is not None else "{}"
-                activity.append(f"🛠 Tool call • `{part.tool_name}` args={args}")
+                tool_call_detected = True
+                payload = part.args if part.args is not None else {}
+                block = payload_block(payload)
+                label = f"🛠 Tool call • `{part.tool_name}`"
+                tool_activity.append(f"{label}\n\n{block}" if block else label)
             elif isinstance(part, (ToolReturnPart, BuiltinToolReturnPart)):
-                result = json.dumps(part.content, ensure_ascii=False) if part.content is not None else "null"
-                activity.append(f"📥 Tool result • `{part.tool_name}` → {result}")
+                tool_call_detected = True
+                block = payload_block(part.content)
+                label = f"📥 Tool result • `{part.tool_name}`"
+                tool_activity.append(f"{label}\n\n{block}" if block else label)
 
-    return activity
+    if tool_call_detected:
+        combined = context_activity + tool_activity + post_call_activity
+        return combined, True
+
+    return [], False
+
+
+def flatten_exceptions(exc: BaseException) -> List[BaseException]:
+    """Recursively flatten ExceptionGroup hierarchies for human-friendly error reporting."""
+
+    if isinstance(exc, BaseExceptionGroup):
+        flattened: List[BaseException] = []
+        for inner in exc.exceptions:  # type: ignore[attr-defined]
+            flattened.extend(flatten_exceptions(inner))
+        return flattened
+
+    return [exc]
 
 
 # ------------------------
 # Streamlit Setup
 # ------------------------
-st.set_page_config(page_title="Chat + MCP + OAuth Demo", page_icon="🤖")
-st.title("🤖 Chat with MCP + OAuth + Agent Thoughts")
+st.set_page_config(page_title="MCP OAuth DCR Test", page_icon="🤖")
+st.title("MCP OAuth DCR Test")
 
 
 def init_state() -> None:
     """Bootstrap Streamlit session state for chat + agent."""
 
-    if "app_data" not in st.session_state:
-        app_data = AppDataManager.load()
-        st.session_state.app_data = app_data
-    else:
-        app_data = st.session_state.app_data
+    app_data: Optional[AppData] = AppDataManager.load()
+    st.session_state.app_data = app_data
 
-    if isinstance(app_data, AppData):
-        for attr, session_key in (
-            ("oauth_access_token", "access_token"),
-            ("oauth_refresh_token", "refresh_token"),
-            ("oauth_client_id", "oauth_client_id"),
-        ):
-            value = getattr(app_data, attr)
-            if value:
-                st.session_state[session_key] = value
-            else:
-                st.session_state.pop(session_key, None)
+    headers: Dict[str, str] = {}
+    token = (app_data.oauth_access_token if app_data else None) or ""
+    if token:
+        # headers = {"Authorization": f"Bearer {token}"}
+        # value = f"{MCP_AUTH_HEADER_PREFIX}{token}" if MCP_AUTH_HEADER_PREFIX else token
+        headers[MCP_AUTH_KEY] = f"{MCP_AUTH_VALUE_PREFIX}{token}"
+    mcp_server = MCPServerStreamableHTTP(url=MCP_SERVER_URL, headers=headers)
+    st.session_state.mcp_server = mcp_server
+    if "mcp_server_tools" not in st.session_state:
+        st.session_state.mcp_server_tools = None
+        st.session_state.mcp_server_tools_error = None
 
-    if "agent_config" not in st.session_state:
-        st.session_state.agent_config = load_agent_settings()
+    agent = Agent(
+        model=MODEL_NAME,
+        toolsets=[mcp_server],
+        system_prompt=SYSTEM_PROMPT,
+    )
+    st.session_state.agent = agent
 
-    if "agent" not in st.session_state:
-        st.session_state.agent = build_agent(
-            st.session_state.agent_config["model"],
-            toolsets=st.session_state.agent_config.get("toolsets"),
-        )
+    oauth_metadata = discover_oauth_metadata(OAUTH_SERVER)
+    st.session_state.oauth_metadata = oauth_metadata
 
     if "messages" not in st.session_state:
         st.session_state.messages = []
@@ -244,99 +310,204 @@ def init_state() -> None:
 init_state()
 
 
-def render_sidebar(agent_config: Dict[str, Any]) -> None:
+def render_sidebar() -> None:
     """Display sidebar controls and quick info."""
 
     with st.sidebar:
-        st.subheader("Session Controls")
-        st.caption("Prototype uses hard-coded model & API key. Later steps move these to env vars.")
+        st.subheader("Session")
+        # st.caption("Prototype uses hard-coded model & API key. Later steps move these to env vars.")
 
-        if st.button("🔄 Reset conversation", use_container_width=True):
+        if st.button("New conversation", use_container_width=True):
             st.session_state.messages = []
-            st.experimental_rerun()
+            st.rerun()
 
         st.divider()
-        st.subheader("Model Info")
-        st.write(
-            {
-                "model": agent_config.get("model"),
-                "api_key_source": "env" if os.getenv("OPENAI_API_KEY") else "missing",
-            }
-        )
+        st.subheader("Agent Info")
+        st.write({"model": MODEL_NAME, "prompt": SYSTEM_PROMPT})
 
         st.divider()
-        st.subheader("MCP Toolset")
-        mcp_meta = agent_config.get("mcp_meta", {})
+        st.subheader("MCP Config")
+        tools_state = st.session_state.get("mcp_server_tools")
+        tools_error = st.session_state.get("mcp_server_tools_error")
+        if tools_state is None:
+            with st.spinner("Loading MCP tools list…"):
+                try:
+                    tools = asyncio.run(st.session_state.mcp_server.list_tools())
+                except Exception as exc:  # pragma: no cover - Streamlit UI path
+                    tools_state = []
+                    tools_error = truncate(str(exc), 120)
+                else:
+                    tools_state = [tool.name for tool in tools]
+                    tools_error = None
+            st.session_state.mcp_server_tools = tools_state
+            st.session_state.mcp_server_tools_error = tools_error
+
+        if tools_error:
+            tools_display: Any = f"Error: {tools_error}"
+        else:
+            tools_display = tools_state or []
+
         st.write(
             {
-                "method": mcp_meta.get("method", "off"),
-                "status": mcp_meta.get("status", "disabled"),
-                "detail": mcp_meta.get("detail", ""),
-                "token": "set" if mcp_meta.get("token_present") else "missing",
+                "url": st.session_state.mcp_server.url,
+                "auth_header_key": MCP_AUTH_KEY,
+                "auth_header_value": (
+                    truncate(st.session_state.app_data.oauth_access_token, 20)
+                    if st.session_state.app_data and st.session_state.app_data.oauth_access_token
+                    else "unset"
+                ),
+                "tools": tools_display,
             }
         )
-        if mcp_meta.get("status") == "error":
-            st.warning(mcp_meta.get("detail"))
 
         st.divider()
         st.subheader("App Data")
-        app_data_obj = st.session_state.get("app_data")
-        app_data = asdict(app_data_obj) if isinstance(app_data_obj, AppData) else {}
+        app_data = st.session_state.get("app_data")
+
         st.write(
             {
-                "client_id": "set" if app_data.get("oauth_client_id") else "missing",
-                "access_token": "set" if app_data.get("oauth_access_token") else "missing",
-                "refresh_token": "set" if app_data.get("oauth_refresh_token") else "missing",
+                "client_id": app_data.oauth_client_id if app_data else "unset",
+                "access_token": truncate(app_data.oauth_access_token, 20) if app_data.oauth_access_token else "unset",
+                "refresh_token": truncate(app_data.oauth_refresh_token, 20) if app_data.oauth_refresh_token else "unset",
             }
         )
 
 
-render_sidebar(st.session_state.agent_config)
+render_sidebar()
 
 # ------------------------
 # OAuth Workflow
 # ------------------------
-if "access_token" not in st.session_state:
-    params = st.query_params
-    code = params.get("code", [None])[0]
+metadata_error = st.session_state.get("oauth_metadata_error")
+metadata = st.session_state.get("oauth_metadata")
 
-    if code:
-        # Exchange code for tokens
-        resp = requests.post(
-            TOKEN_URL,
-            data={
-                "grant_type": "authorization_code",
-                "code": code,
-                "redirect_uri": REDIRECT_URI,
-                "client_id": CLIENT_ID,
-                "client_secret": CLIENT_SECRET,
-            },
+if metadata_error:
+    st.error(f"OAuth discovery failed: {metadata_error}")
+elif metadata:
+    params = st.query_params
+
+    def first_value(raw: Any) -> str | None:
+        if raw is None:
+            return None
+        if isinstance(raw, (list, tuple)):
+            return raw[0]
+        return str(raw)
+
+    code = first_value(params.get("code"))
+    returned_state = first_value(params.get("state"))
+    processing_callback = bool(code)
+
+    register_url = metadata.registration_endpoint or REGISTER_FALLBACK_URL
+    st.markdown(
+        f'<a href="{register_url}" target="_blank" rel="noopener">📝 Register App</a>',
+        unsafe_allow_html=True,
+    )
+
+    stored_client_id = st.session_state.app_data.oauth_client_id
+    with st.form(key="client-id-form"):
+        client_id_input = st.text_input(
+            "OAuth Client ID",
+            stored_client_id or "",
+            help="Paste the client identifier generated after registration",
         )
-        tokens = resp.json()
-        if "access_token" in tokens:
-            st.session_state["access_token"] = tokens["access_token"]
-            st.session_state["refresh_token"] = tokens.get("refresh_token")
+        submitted = st.form_submit_button("Save Client ID")
+        if submitted:
+            client_id_value = client_id_input.strip() or None
             new_app_data = AppDataManager.update(
-                st.session_state.get("app_data"),
-                oauth_client_id=st.session_state.get("oauth_client_id") or CLIENT_ID,
-                oauth_access_token=tokens["access_token"],
-                oauth_refresh_token=tokens.get("refresh_token"),
+                st.session_state.app_data,
+                oauth_client_id=client_id_value,
             )
             st.session_state.app_data = new_app_data
-            if "agent_config" in st.session_state:
-                st.session_state.agent_config["app_data"] = asdict(new_app_data)
-            st.success("✅ Access token obtained")
+            if client_id_value:
+                st.session_state["oauth_client_id"] = client_id_value
+            else:
+                st.session_state.pop("oauth_client_id", None)
+            if client_id_value:
+                st.success("Client ID saved. Continue with authorization when ready.")
+            else:
+                st.info("Client ID cleared. Registration must be completed before continuing.")
+
+    client_id = st.session_state.get("oauth_client_id")
+    if client_id:
+        if "oauth_state" not in st.session_state:
+            st.session_state.oauth_state = secrets.token_urlsafe(24)
+
+        if "pkce_verifier" not in st.session_state or "pkce_challenge" not in st.session_state:
+            code_verifier, code_challenge, method = generate_pkce_pair()
+            st.session_state.pkce_verifier = code_verifier
+            st.session_state.pkce_challenge = code_challenge
+            st.session_state.pkce_method = method
+        elif not processing_callback:
+            challenge, method = build_pkce_challenge(st.session_state.pkce_verifier)
+            st.session_state.pkce_challenge = challenge
+            st.session_state.pkce_method = method
+
+        authorize_params = {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": REDIRECT_URI,
+            "scope": OAUTH_SCOPE,
+            "state": st.session_state.oauth_state,
+            "code_challenge": st.session_state.pkce_challenge,
+            "code_challenge_method": st.session_state.pkce_method,
+        }
+        authorize_url = f"{metadata.authorization_endpoint}?{urlencode(authorize_params)}"
+        st.markdown(
+            f'<a href="{authorize_url}" target="_blank" rel="noopener">🔐 Authorize Agent</a>',
+            unsafe_allow_html=True,
+        )
+
+    if code and client_id:
+        expected_state = st.session_state.get("oauth_state")
+        if expected_state and returned_state and returned_state != expected_state:
+            st.error(f"State mismatch detected. Expected {expected_state!r}, got {returned_state!r}. Restart the authorization flow.")
         else:
-            st.error(f"Token exchange failed: {tokens}")
-    else:
-        # Show login link
-        login_url = f"{AUTH_URL}?response_type=code&client_id={CLIENT_ID}" f"&redirect_uri={REDIRECT_URI}"
-        st.markdown(f"[🔑 Login with OAuth]({login_url})")
+            code_verifier = st.session_state.get("pkce_verifier")
+            if not code_verifier:
+                st.error("PKCE verifier missing. Restart the authorization flow.")
+            else:
+                try:
+                    tokens = exchange_code_for_tokens(
+                        metadata.token_endpoint,
+                        authorization_code=code,
+                        client_id=client_id,
+                        redirect_uri=REDIRECT_URI,
+                        code_verifier=code_verifier,
+                        state=returned_state,
+                    )
+                except Exception as exc:  # pragma: no cover - Streamlit UI path
+                    st.error(f"Token exchange failed: {exc}")
+                else:
+                    access_token = tokens.get("access_token")
+                    if not access_token:
+                        st.error("Token response missing access token. Restart the flow.")
+                    else:
+                        st.session_state["access_token"] = access_token
+                        refresh_token = tokens.get("refresh_token")
+                        if refresh_token:
+                            st.session_state["refresh_token"] = refresh_token
+
+                        new_app_data = AppDataManager.update(
+                            st.session_state.app_data,
+                            oauth_client_id=client_id,
+                            oauth_access_token=access_token,
+                            oauth_refresh_token=refresh_token,
+                        )
+
+                        st.success("✅ Access token obtained")
+
+                        for key in [
+                            "oauth_state",
+                            "pkce_verifier",
+                            "pkce_challenge",
+                            "pkce_method",
+                        ]:
+                            st.session_state.pop(key, None)
+
+                        st.experimental_set_query_params()
 
 
 def render_chat_history(messages: List[Dict[str, str]]) -> None:
-    """Display prior chat messages in conversational bubbles."""
-
     for message in messages:
         with st.chat_message(message["role"]):
             st.markdown(message["content"])
@@ -346,8 +517,6 @@ render_chat_history(st.session_state.messages)
 
 
 def handle_chat_turn(prompt: str) -> None:
-    """Process a single chat turn, updating history and agent traces."""
-
     st.session_state.messages.append({"role": "user", "content": prompt})
     with st.chat_message("user"):
         st.markdown(prompt)
@@ -358,20 +527,50 @@ def handle_chat_turn(prompt: str) -> None:
         response_placeholder = st.empty()
 
         async def run_agent() -> None:
+            response_placeholder.markdown(MODEL_RESPONSE_SPINNER, unsafe_allow_html=True)
             try:
                 result = await agent.run(prompt)
             except Exception as exc:  # pragma: no cover - Streamlit UI path
-                response_placeholder.error(f"Agent run failed: {exc}")
+                flattened = flatten_exceptions(exc)
+                http_error = next((err for err in flattened if isinstance(err, httpx.HTTPStatusError)), None)
+                if http_error is not None:
+                    response = http_error.response
+                    info = ""
+                    if response is not None:
+                        reader = getattr(response, "aread", None)
+                        try:
+                            if callable(reader):
+                                await reader()
+                            else:
+                                response.read()  # type: ignore[func-returns-value]
+                        except Exception:  # pragma: no cover - best effort to read body
+                            pass
+                        else:
+                            try:
+                                info = truncate(response.text or "", 120)
+                            except httpx.ResponseNotRead:  # pragma: no cover - should be rare
+                                info = ""
+
+                    status = response.status_code if response is not None else "?"
+                    reason = response.reason_phrase if response is not None else ""
+                    message = f"MCP request failed: {status} {reason}".rstrip()
+
+                    if info:
+                        message += f" — {info}"
+                else:
+                    message = str(exc)
+                response_placeholder.error(f"Agent run failed: {message}")
                 return
 
             response_text = result.output if isinstance(result.output, str) else str(result.output)
-            response_placeholder.markdown(response_text)
 
-            tool_activity = extract_tool_activity(result.new_messages())
-            if tool_activity:
-                with st.expander("🤔 Agent Activity", expanded=False):
+            tool_activity, tool_call_detected = extract_tool_activity(result.new_messages())
+            if tool_call_detected and tool_activity:
+                with st.expander("Agent Activity", expanded=False):
                     for entry in tool_activity:
                         st.markdown(entry)
+
+            response_placeholder.markdown(response_text)
 
             st.session_state.messages.append({"role": "assistant", "content": response_text})
 

--- a/agent/app_data_store.py
+++ b/agent/app_data_store.py
@@ -1,0 +1,263 @@
+"""Persistence helpers for Streamlit agent OAuth data."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_AGENT_DIR = Path(__file__).resolve().parent
+_DEFAULT_FILE = _AGENT_DIR / ".app_data.json"
+_USER_FILE_TEMPLATE = ".app_user_data-{slug}.json"
+_UNSET = object()
+
+
+def _slugify_user_id(user_id: str) -> str:
+    """Return a filesystem-friendly slug for storing user-specific data."""
+
+    normalized = user_id.strip()
+    if not normalized:
+        return "default"
+
+    slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", normalized)
+    slug = slug.strip("-")
+    return slug.lower() or "default"
+
+
+@dataclass
+class AppData:
+    user_id: Optional[str] = None
+    user_access_token: Optional[str] = None
+    user_refresh_token: Optional[str] = None
+    oauth_client_id: Optional[str] = None
+    oauth_access_token: Optional[str] = None
+    oauth_refresh_token: Optional[str] = None
+    registration_access_token: Optional[str] = None
+    registration_client_uri: Optional[str] = None
+
+    @classmethod
+    def from_json(cls, payload: Dict[str, Any]) -> "AppData":
+        known_fields = {
+            "user_id": payload.get("user_id"),
+            "user_access_token": payload.get("user_access_token"),
+            "user_refresh_token": payload.get("user_refresh_token"),
+            "oauth_client_id": payload.get("oauth_client_id"),
+            "oauth_access_token": payload.get("oauth_access_token"),
+            "oauth_refresh_token": payload.get("oauth_refresh_token"),
+            "registration_access_token": payload.get("registration_access_token"),
+            "registration_client_uri": payload.get("registration_client_uri"),
+        }
+        return cls(**known_fields)
+
+    def to_json(self) -> Dict[str, Any]:
+        data = asdict(self)
+        return data
+
+    def user_auth(self) -> "UserAuthState":
+        return UserAuthState(
+            user_id=self.user_id,
+            access_token=self.user_access_token,
+            refresh_token=self.user_refresh_token,
+        )
+
+    def app_auth(self) -> "AppAuthState":
+        return AppAuthState(
+            client_id=self.oauth_client_id,
+            access_token=self.oauth_access_token,
+            refresh_token=self.oauth_refresh_token,
+            registration_access_token=self.registration_access_token,
+            registration_client_uri=self.registration_client_uri,
+        )
+
+
+class AppDataStore:
+    """Manage persistence of :class:`AppData` objects per user."""
+
+    @staticmethod
+    def _path_for_user(user_id: Optional[str]) -> Path:
+        if not user_id:
+            return _DEFAULT_FILE
+
+        slug = _slugify_user_id(user_id)
+        return _AGENT_DIR / _USER_FILE_TEMPLATE.format(slug=slug)
+
+    @staticmethod
+    def _pointer_path() -> Path:
+        return _AGENT_DIR / ".app_data.meta.json"
+
+    @classmethod
+    def _read_last_user_id(cls) -> Optional[str]:
+        path = cls._pointer_path()
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            path.unlink(missing_ok=True)
+            return None
+
+        if not isinstance(data, dict):
+            path.unlink(missing_ok=True)
+            return None
+
+        hinted = data.get("active_user_id")
+        if isinstance(hinted, str) and hinted.strip():
+            return hinted.strip()
+        return None
+
+    @classmethod
+    def _write_last_user_id(cls, user_id: Optional[str]) -> None:
+        path = cls._pointer_path()
+        if not user_id:
+            path.unlink(missing_ok=True)
+            return
+
+        payload = json.dumps({"active_user_id": user_id}, indent=2, sort_keys=True)
+        path.write_text(payload, encoding="utf-8")
+
+    @classmethod
+    def load(cls, user_id: Optional[str] = None) -> Optional[AppData]:
+        path = cls._path_for_user(user_id)
+
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            if user_id is None:
+                # Fallback: if the default file is missing but we stored a user pointer elsewhere,
+                # attempt to resolve using the last-known user slug.
+                pointer = cls._read_last_user_id()
+                if pointer:
+                    return cls.load(pointer)
+            return None
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        # Legacy pointer-only payloads may only carry ``active_user_id`` to hint at the last session.
+        if "user_id" not in data:
+            hinted_user = data.get("active_user_id")
+            if isinstance(hinted_user, str) and hinted_user.strip():
+                return cls.load(hinted_user.strip())
+            return None
+
+        return AppData.from_json(data)
+
+    @classmethod
+    def save(cls, data: AppData) -> None:
+        path = cls._path_for_user(data.user_id)
+        payload = json.dumps(data.to_json(), indent=2, sort_keys=True)
+        path.write_text(payload, encoding="utf-8")
+
+        if data.user_id:
+            cls._write_last_user_id(data.user_id)
+            # Mirror the latest snapshot into the default file so a fresh session can recover quickly.
+            _DEFAULT_FILE.write_text(payload, encoding="utf-8")
+        else:
+            # If ``user_id`` is cleared, drop the pointer metadata and default snapshot.
+            cls._write_last_user_id(None)
+            _DEFAULT_FILE.write_text(payload, encoding="utf-8")
+
+    @classmethod
+    def update(
+        cls,
+        current: Optional[AppData],
+        *,
+        user_id: Optional[str] | object = _UNSET,
+        user_access_token: Optional[str] | object = _UNSET,
+        user_refresh_token: Optional[str] | object = _UNSET,
+        oauth_client_id: Optional[str] | object = _UNSET,
+        oauth_access_token: Optional[str] | object = _UNSET,
+        oauth_refresh_token: Optional[str] | object = _UNSET,
+        registration_access_token: Optional[str] | object = _UNSET,
+        registration_client_uri: Optional[str] | object = _UNSET,
+    ) -> AppData:
+        base = current or AppData()
+
+        payload = {
+            "user_id": base.user_id,
+            "user_access_token": base.user_access_token,
+            "user_refresh_token": base.user_refresh_token,
+            "oauth_client_id": base.oauth_client_id,
+            "oauth_access_token": base.oauth_access_token,
+            "oauth_refresh_token": base.oauth_refresh_token,
+            "registration_access_token": base.registration_access_token,
+            "registration_client_uri": base.registration_client_uri,
+        }
+
+        if user_id is not _UNSET:
+            payload["user_id"] = user_id
+        if user_access_token is not _UNSET:
+            payload["user_access_token"] = user_access_token
+        if user_refresh_token is not _UNSET:
+            payload["user_refresh_token"] = user_refresh_token
+        if oauth_access_token is not _UNSET:
+            payload["oauth_access_token"] = oauth_access_token
+        if oauth_refresh_token is not _UNSET:
+            payload["oauth_refresh_token"] = oauth_refresh_token
+        if registration_access_token is not _UNSET:
+            payload["registration_access_token"] = registration_access_token
+        if registration_client_uri is not _UNSET:
+            payload["registration_client_uri"] = registration_client_uri
+
+        old_user_id = base.user_id
+        new_user_id = payload["user_id"]
+        if old_user_id and new_user_id != old_user_id:
+            cls.delete(old_user_id)
+
+        updated = AppData(**payload)
+        cls.save(updated)
+        return updated
+
+    @classmethod
+    def delete(cls, user_id: Optional[str] = None) -> None:
+        path = cls._path_for_user(user_id)
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+@dataclass(frozen=True)
+class UserAuthState:
+    """Immutable snapshot of bootstrap user authentication tokens."""
+
+    user_id: Optional[str]
+    access_token: Optional[str]
+    refresh_token: Optional[str]
+
+    @property
+    def is_authenticated(self) -> bool:
+        return bool(self.access_token)
+
+    def effective_user_id(self) -> str:
+        identifier = (self.user_id or "").strip()
+        return identifier or "default"
+
+
+@dataclass(frozen=True)
+class AppAuthState:
+    """Immutable snapshot of registered client credentials and tokens."""
+
+    client_id: Optional[str]
+    access_token: Optional[str]
+    refresh_token: Optional[str]
+    registration_access_token: Optional[str]
+    registration_client_uri: Optional[str]
+
+    @property
+    def is_registered(self) -> bool:
+        return bool(self.client_id)
+
+    @property
+    def is_authorized(self) -> bool:
+        return bool(self.access_token)

--- a/agent/app_data_store.py
+++ b/agent/app_data_store.py
@@ -3,32 +3,17 @@
 from __future__ import annotations
 
 import json
-import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 _AGENT_DIR = Path(__file__).resolve().parent
 _DEFAULT_FILE = _AGENT_DIR / ".app_data.json"
-_USER_FILE_TEMPLATE = ".app_user_data-{slug}.json"
 _UNSET = object()
-
-
-def _slugify_user_id(user_id: str) -> str:
-    """Return a filesystem-friendly slug for storing user-specific data."""
-
-    normalized = user_id.strip()
-    if not normalized:
-        return "default"
-
-    slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", normalized)
-    slug = slug.strip("-")
-    return slug.lower() or "default"
 
 
 @dataclass
 class AppData:
-    user_id: Optional[str] = None
     user_access_token: Optional[str] = None
     user_refresh_token: Optional[str] = None
     oauth_client_id: Optional[str] = None
@@ -36,11 +21,11 @@ class AppData:
     oauth_refresh_token: Optional[str] = None
     registration_access_token: Optional[str] = None
     registration_client_uri: Optional[str] = None
+    registration_client_payload: Optional[Dict[str, Any]] = None
 
     @classmethod
     def from_json(cls, payload: Dict[str, Any]) -> "AppData":
         known_fields = {
-            "user_id": payload.get("user_id"),
             "user_access_token": payload.get("user_access_token"),
             "user_refresh_token": payload.get("user_refresh_token"),
             "oauth_client_id": payload.get("oauth_client_id"),
@@ -49,15 +34,18 @@ class AppData:
             "registration_access_token": payload.get("registration_access_token"),
             "registration_client_uri": payload.get("registration_client_uri"),
         }
+        registration_payload = payload.get("registration_client_payload")
+        if isinstance(registration_payload, dict):
+            known_fields["registration_client_payload"] = registration_payload
+        else:
+            known_fields["registration_client_payload"] = None
         return cls(**known_fields)
 
     def to_json(self) -> Dict[str, Any]:
-        data = asdict(self)
-        return data
+        return asdict(self)
 
     def user_auth(self) -> "UserAuthState":
         return UserAuthState(
-            user_id=self.user_id,
             access_token=self.user_access_token,
             refresh_token=self.user_refresh_token,
         )
@@ -73,23 +61,15 @@ class AppData:
 
 
 class AppDataStore:
-    """Manage persistence of :class:`AppData` objects per user."""
+    """Manage persistence of :class:`AppData` objects."""
 
     @staticmethod
-    def _path_for_user(user_id: Optional[str]) -> Path:
-        if not user_id:
-            return _DEFAULT_FILE
-
-        slug = _slugify_user_id(user_id)
-        return _AGENT_DIR / _USER_FILE_TEMPLATE.format(slug=slug)
-
-    @staticmethod
-    def _pointer_path() -> Path:
-        return _AGENT_DIR / ".app_data.meta.json"
+    def _data_path() -> Path:
+        return _DEFAULT_FILE
 
     @classmethod
-    def _read_last_user_id(cls) -> Optional[str]:
-        path = cls._pointer_path()
+    def load(cls) -> Optional[AppData]:
+        path = cls._data_path()
         try:
             raw = path.read_text(encoding="utf-8")
         except FileNotFoundError:
@@ -98,81 +78,23 @@ class AppDataStore:
         try:
             data = json.loads(raw)
         except json.JSONDecodeError:
-            path.unlink(missing_ok=True)
             return None
 
         if not isinstance(data, dict):
-            path.unlink(missing_ok=True)
-            return None
-
-        hinted = data.get("active_user_id")
-        if isinstance(hinted, str) and hinted.strip():
-            return hinted.strip()
-        return None
-
-    @classmethod
-    def _write_last_user_id(cls, user_id: Optional[str]) -> None:
-        path = cls._pointer_path()
-        if not user_id:
-            path.unlink(missing_ok=True)
-            return
-
-        payload = json.dumps({"active_user_id": user_id}, indent=2, sort_keys=True)
-        path.write_text(payload, encoding="utf-8")
-
-    @classmethod
-    def load(cls, user_id: Optional[str] = None) -> Optional[AppData]:
-        path = cls._path_for_user(user_id)
-
-        try:
-            raw = path.read_text(encoding="utf-8")
-        except FileNotFoundError:
-            if user_id is None:
-                # Fallback: if the default file is missing but we stored a user pointer elsewhere,
-                # attempt to resolve using the last-known user slug.
-                pointer = cls._read_last_user_id()
-                if pointer:
-                    return cls.load(pointer)
-            return None
-
-        try:
-            data = json.loads(raw)
-        except json.JSONDecodeError:
-            return None
-
-        if not isinstance(data, dict):
-            return None
-
-        # Legacy pointer-only payloads may only carry ``active_user_id`` to hint at the last session.
-        if "user_id" not in data:
-            hinted_user = data.get("active_user_id")
-            if isinstance(hinted_user, str) and hinted_user.strip():
-                return cls.load(hinted_user.strip())
             return None
 
         return AppData.from_json(data)
 
     @classmethod
     def save(cls, data: AppData) -> None:
-        path = cls._path_for_user(data.user_id)
         payload = json.dumps(data.to_json(), indent=2, sort_keys=True)
-        path.write_text(payload, encoding="utf-8")
-
-        if data.user_id:
-            cls._write_last_user_id(data.user_id)
-            # Mirror the latest snapshot into the default file so a fresh session can recover quickly.
-            _DEFAULT_FILE.write_text(payload, encoding="utf-8")
-        else:
-            # If ``user_id`` is cleared, drop the pointer metadata and default snapshot.
-            cls._write_last_user_id(None)
-            _DEFAULT_FILE.write_text(payload, encoding="utf-8")
+        cls._data_path().write_text(payload, encoding="utf-8")
 
     @classmethod
     def update(
         cls,
         current: Optional[AppData],
         *,
-        user_id: Optional[str] | object = _UNSET,
         user_access_token: Optional[str] | object = _UNSET,
         user_refresh_token: Optional[str] | object = _UNSET,
         oauth_client_id: Optional[str] | object = _UNSET,
@@ -180,11 +102,11 @@ class AppDataStore:
         oauth_refresh_token: Optional[str] | object = _UNSET,
         registration_access_token: Optional[str] | object = _UNSET,
         registration_client_uri: Optional[str] | object = _UNSET,
+        registration_client_payload: Optional[Dict[str, Any]] | object = _UNSET,
     ) -> AppData:
         base = current or AppData()
 
         payload = {
-            "user_id": base.user_id,
             "user_access_token": base.user_access_token,
             "user_refresh_token": base.user_refresh_token,
             "oauth_client_id": base.oauth_client_id,
@@ -192,14 +114,15 @@ class AppDataStore:
             "oauth_refresh_token": base.oauth_refresh_token,
             "registration_access_token": base.registration_access_token,
             "registration_client_uri": base.registration_client_uri,
+            "registration_client_payload": base.registration_client_payload,
         }
 
-        if user_id is not _UNSET:
-            payload["user_id"] = user_id
         if user_access_token is not _UNSET:
             payload["user_access_token"] = user_access_token
         if user_refresh_token is not _UNSET:
             payload["user_refresh_token"] = user_refresh_token
+        if oauth_client_id is not _UNSET:
+            payload["oauth_client_id"] = oauth_client_id
         if oauth_access_token is not _UNSET:
             payload["oauth_access_token"] = oauth_access_token
         if oauth_refresh_token is not _UNSET:
@@ -208,40 +131,28 @@ class AppDataStore:
             payload["registration_access_token"] = registration_access_token
         if registration_client_uri is not _UNSET:
             payload["registration_client_uri"] = registration_client_uri
-
-        old_user_id = base.user_id
-        new_user_id = payload["user_id"]
-        if old_user_id and new_user_id != old_user_id:
-            cls.delete(old_user_id)
+        if registration_client_payload is not _UNSET:
+            payload["registration_client_payload"] = registration_client_payload
 
         updated = AppData(**payload)
         cls.save(updated)
         return updated
 
     @classmethod
-    def delete(cls, user_id: Optional[str] = None) -> None:
-        path = cls._path_for_user(user_id)
-        try:
-            path.unlink()
-        except FileNotFoundError:
-            pass
+    def delete(cls) -> None:
+        cls._data_path().unlink(missing_ok=True)
 
 
 @dataclass(frozen=True)
 class UserAuthState:
     """Immutable snapshot of bootstrap user authentication tokens."""
 
-    user_id: Optional[str]
     access_token: Optional[str]
     refresh_token: Optional[str]
 
     @property
     def is_authenticated(self) -> bool:
         return bool(self.access_token)
-
-    def effective_user_id(self) -> str:
-        identifier = (self.user_id or "").strip()
-        return identifier or "default"
 
 
 @dataclass(frozen=True)

--- a/agent/oauth.py
+++ b/agent/oauth.py
@@ -53,10 +53,12 @@ def discover_oauth_metadata(oauth_server_url: str) -> OAuthMetadata:
     try:
         response = requests.get(oauth_metadata_endpoint, timeout=10)
     except requests.RequestException as exc:  # pragma: no cover - network failure path
-        raise OAuthDiscoveryError(f"OAuth discovery failed: {exc}") from exc
+        raise OAuthDiscoveryError(f"OAuth discovery failed for {oauth_server_url}: {exc}") from exc
 
     if response.status_code != 200:
-        raise OAuthDiscoveryError(f"OAuth discovery failed: {response.status_code} {response.reason}")  # pragma: no cover - unexpected status
+        raise OAuthDiscoveryError(
+            f"OAuth discovery failed for {oauth_server_url}: {response.status_code} {response.reason}"
+        )  # pragma: no cover - unexpected status
 
     data = response.json()
     if not isinstance(data, Mapping):

--- a/agent/oauth.py
+++ b/agent/oauth.py
@@ -49,8 +49,9 @@ def _normalize_registration_endpoint(data: Mapping[str, Any]) -> str | None:
 def discover_oauth_metadata(oauth_server_url: str) -> OAuthMetadata:
     """Retrieve the OAuth discovery metadata and cache the result."""
 
+    oauth_metadata_endpoint = f"{oauth_server_url}/.well-known/oauth-authorization-server"
     try:
-        response = requests.get(oauth_server_url, timeout=10)
+        response = requests.get(oauth_metadata_endpoint, timeout=10)
     except requests.RequestException as exc:  # pragma: no cover - network failure path
         raise OAuthDiscoveryError(f"OAuth discovery failed: {exc}") from exc
 

--- a/agent/oauth.py
+++ b/agent/oauth.py
@@ -1,0 +1,129 @@
+"""OAuth helper utilities for the Streamlit agent."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, Dict, Mapping, MutableMapping, Tuple
+
+import requests
+
+from mybooks.utils import build_code_challenge, get_code_verifier
+
+
+class OAuthDiscoveryError(RuntimeError):
+    """Raised when the OAuth server metadata cannot be fetched or parsed."""
+
+
+@dataclass(frozen=True)
+class OAuthMetadata:
+    """Resolved OAuth discovery document."""
+
+    issuer: str
+    authorization_endpoint: str
+    token_endpoint: str
+    registration_endpoint: str | None
+
+
+# def build_code_challenge(code_verifier: str) -> str:
+#     """Derive a PKCE code challenge from a verifier."""
+#     digest = hashlib.sha256(code_verifier.encode("utf-8")).digest()
+#     return base64.urlsafe_b64encode(digest).decode("utf-8").replace("=", "")
+
+
+# def get_code_verifier() -> Tuple[str, str]:
+#     """Generate a code verifier and its corresponding code challenge for OAuth 2.0 PKCE."""
+#     code_verifier = "".join(random.choice(string.ascii_uppercase + string.digits) for _ in range(random.randint(43, 128)))
+#     code_challenge = build_code_challenge(code_verifier)
+#     return code_verifier, code_challenge
+
+
+def _normalize_registration_endpoint(data: Mapping[str, Any]) -> str | None:
+    endpoint = data.get("registration_endpoint")
+    if isinstance(endpoint, str) and endpoint.strip():
+        return endpoint.strip()
+    return None
+
+
+@lru_cache(maxsize=1)
+def discover_oauth_metadata(oauth_server_url: str) -> OAuthMetadata:
+    """Retrieve the OAuth discovery metadata and cache the result."""
+
+    try:
+        response = requests.get(oauth_server_url, timeout=10)
+    except requests.RequestException as exc:  # pragma: no cover - network failure path
+        raise OAuthDiscoveryError(f"OAuth discovery failed: {exc}") from exc
+
+    if response.status_code != 200:
+        raise OAuthDiscoveryError(f"OAuth discovery failed: {response.status_code} {response.reason}")  # pragma: no cover - unexpected status
+
+    data = response.json()
+    if not isinstance(data, Mapping):
+        raise OAuthDiscoveryError("OAuth discovery document is not a JSON object")
+
+    try:
+        issuer = str(data["issuer"]).strip()
+        authorization_endpoint = str(data["authorization_endpoint"]).strip()
+        token_endpoint = str(data["token_endpoint"]).strip()
+    except KeyError as exc:
+        raise OAuthDiscoveryError(f"OAuth discovery document missing field: {exc.args[0]}") from exc
+
+    if not issuer or not authorization_endpoint or not token_endpoint:
+        raise OAuthDiscoveryError("OAuth discovery document returned empty endpoints")
+
+    registration_endpoint = _normalize_registration_endpoint(data)
+    return OAuthMetadata(
+        issuer=issuer,
+        authorization_endpoint=authorization_endpoint,
+        token_endpoint=token_endpoint,
+        registration_endpoint=registration_endpoint,
+    )
+
+
+def generate_pkce_pair() -> Tuple[str, str, str]:
+    """Return ``(code_verifier, code_challenge, method)``."""
+
+    code_verifier, code_challenge = get_code_verifier()
+    return code_verifier, code_challenge, "S256"
+
+
+def build_pkce_challenge(code_verifier: str) -> Tuple[str, str]:
+    """Compute the PKCE challenge for a pre-existing verifier."""
+
+    return build_code_challenge(code_verifier), "S256"
+
+
+def exchange_code_for_tokens(
+    token_endpoint: str,
+    *,
+    authorization_code: str,
+    client_id: str,
+    redirect_uri: str,
+    code_verifier: str,
+    state: str | None = None,
+    session: requests.Session | None = None,
+) -> Dict[str, Any]:
+    """Exchange an authorization code for tokens using PKCE."""
+
+    payload: MutableMapping[str, Any] = {
+        "grant_type": "authorization_code",
+        "code": authorization_code,
+        "redirect_uri": redirect_uri,
+        "client_id": client_id,
+        "code_verifier": code_verifier,
+    }
+    if state:
+        payload["state"] = state
+
+    transport = session or requests
+    response = transport.post(
+        token_endpoint,
+        data=payload,
+        headers={"Content-Type": "application/x-www-form-urlencoded", "Cache-Control": "no-cache"},
+        timeout=10,
+    )
+    response.raise_for_status()
+    token_data = response.json()
+    if not isinstance(token_data, Mapping):
+        raise RuntimeError("Token endpoint returned non-JSON response")
+    return dict(token_data)

--- a/agent/oauth_flow.py
+++ b/agent/oauth_flow.py
@@ -1,0 +1,317 @@
+"""Lightweight OAuth flow helpers storing transient state on disk."""
+
+from __future__ import annotations
+
+import json
+import secrets
+import tempfile
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+from urllib.parse import urlencode
+
+import requests
+from oauth import exchange_code_for_tokens, generate_pkce_pair
+
+FLOW_USER_LOGIN = "user_login"
+FLOW_APP_AUTHORIZE = "app_authorize"
+
+
+class OAuthFlowError(RuntimeError):
+    """Raised when an OAuth flow encounters an unrecoverable error."""
+
+
+def _flow_path(name: str) -> Path:
+    safe = name.replace("/", "-")
+    return Path(tempfile.gettempdir()) / f"agent-oauth-{safe}.json"
+
+
+@dataclass
+class OAuthFlowState:
+    """Structured snapshot of transient OAuth flow data."""
+
+    client_id: str
+    redirect_uri: str
+    scope: str
+    code_verifier: str
+    code_challenge: str
+    code_challenge_method: str
+    state: str
+
+    @classmethod
+    def new(cls, *, client_id: str, redirect_uri: str, scope: str) -> "OAuthFlowState":
+        verifier, challenge, method = generate_pkce_pair()
+        return cls(
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            scope=scope,
+            code_verifier=verifier,
+            code_challenge=challenge,
+            code_challenge_method=method,
+            state=secrets.token_urlsafe(24),
+        )
+
+    @classmethod
+    def from_json(cls, payload: Mapping[str, Any]) -> Optional["OAuthFlowState"]:
+        try:
+            client_id = str(payload["client_id"])
+            redirect_uri = str(payload["redirect_uri"])
+            scope = str(payload["scope"])
+            code_verifier = str(payload["code_verifier"])
+            code_challenge = str(payload["code_challenge"])
+            code_challenge_method = str(payload["code_challenge_method"])
+            state = str(payload["state"])
+        except KeyError:
+            return None
+
+        if not all((client_id, redirect_uri, scope, code_verifier, code_challenge, code_challenge_method, state)):
+            return None
+
+        return cls(
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            scope=scope,
+            code_verifier=code_verifier,
+            code_challenge=code_challenge,
+            code_challenge_method=code_challenge_method,
+            state=state,
+        )
+
+    def to_json(self) -> Dict[str, str]:
+        return {
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+            "scope": self.scope,
+            "code_verifier": self.code_verifier,
+            "code_challenge": self.code_challenge,
+            "code_challenge_method": self.code_challenge_method,
+            "state": self.state,
+        }
+
+    def with_context(self, *, client_id: str, redirect_uri: str, scope: str) -> "OAuthFlowState":
+        return replace(self, client_id=client_id, redirect_uri=redirect_uri, scope=scope)
+
+
+class OAuthFlowStore:
+    """Disk-backed storage for transient :class:`OAuthFlowState`."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @property
+    def path(self) -> Path:
+        return _flow_path(self.name)
+
+    def load(self) -> Optional[OAuthFlowState]:
+        try:
+            raw = self.path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            self.clear()
+            return None
+
+        if not isinstance(payload, Mapping):
+            self.clear()
+            return None
+
+        state = OAuthFlowState.from_json(payload)
+        if state is None:
+            self.clear()
+        return state
+
+    def save(self, state: OAuthFlowState) -> None:
+        self.path.write_text(json.dumps(state.to_json(), indent=2, sort_keys=True), encoding="utf-8")
+
+    def clear(self) -> None:
+        self.path.unlink(missing_ok=True)
+
+
+class AuthorizationFlow:
+    """Handle starting and completing a single OAuth authorization-code flow."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._store = OAuthFlowStore(name)
+
+    def start(
+        self,
+        *,
+        client_id: str,
+        scope: str,
+        redirect_uri: str,
+        authorization_endpoint: str,
+        reuse_existing: bool = False,
+    ) -> str:
+        state = self._store.load() if reuse_existing else None
+        if state is None:
+            state = OAuthFlowState.new(client_id=client_id, redirect_uri=redirect_uri, scope=scope)
+        else:
+            state = state.with_context(client_id=client_id, redirect_uri=redirect_uri, scope=scope)
+
+        self._store.save(state)
+
+        params = {
+            "response_type": "code",
+            "client_id": state.client_id,
+            "redirect_uri": state.redirect_uri,
+            "scope": state.scope,
+            "state": state.state,
+            "code_challenge": state.code_challenge,
+            "code_challenge_method": state.code_challenge_method,
+        }
+        return f"{authorization_endpoint}?{urlencode(params)}"
+
+    def complete(
+        self,
+        *,
+        code: str,
+        returned_state: Optional[str],
+        token_endpoint: str,
+        client_id_override: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        state = self._store.load()
+        if state is None:
+            raise OAuthFlowError("OAuth flow state missing; restart the authorization process.")
+
+        if state.state and returned_state and returned_state != state.state:
+            raise OAuthFlowError("State mismatch detected; restart the authorization process.")
+
+        client_id = client_id_override or state.client_id
+        if not client_id:
+            raise OAuthFlowError("OAuth flow client_id missing; restart the authorization process.")
+
+        tokens = exchange_code_for_tokens(
+            token_endpoint,
+            authorization_code=code,
+            client_id=client_id,
+            redirect_uri=state.redirect_uri,
+            code_verifier=state.code_verifier,
+            state=returned_state,
+        )
+
+        self.clear()
+        return tokens
+
+    def clear(self) -> None:
+        self._store.clear()
+
+    def matches_state(self, state_value: str) -> bool:
+        state = self._store.load()
+        return bool(state and state.state == state_value)
+
+
+USER_AUTH_FLOW = AuthorizationFlow(FLOW_USER_LOGIN)
+APP_AUTH_FLOW = AuthorizationFlow(FLOW_APP_AUTHORIZE)
+_ALL_FLOWS = (USER_AUTH_FLOW, APP_AUTH_FLOW)
+
+
+def get_flow(name: str) -> AuthorizationFlow:
+    if name == FLOW_USER_LOGIN:
+        return USER_AUTH_FLOW
+    if name == FLOW_APP_AUTHORIZE:
+        return APP_AUTH_FLOW
+    return AuthorizationFlow(name)
+
+
+def start_authorization_flow(
+    *,
+    name: str,
+    client_id: str,
+    scope: str,
+    redirect_uri: str,
+    authorization_endpoint: str,
+    reuse_existing: bool = False,
+) -> str:
+    flow = get_flow(name)
+    return flow.start(
+        client_id=client_id,
+        scope=scope,
+        redirect_uri=redirect_uri,
+        authorization_endpoint=authorization_endpoint,
+        reuse_existing=reuse_existing,
+    )
+
+
+def handle_authorization_callback(
+    *,
+    name: str,
+    code: str,
+    returned_state: Optional[str],
+    token_endpoint: str,
+    client_id_override: Optional[str] = None,
+) -> Dict[str, Any]:
+    flow = get_flow(name)
+    return flow.complete(
+        code=code,
+        returned_state=returned_state,
+        token_endpoint=token_endpoint,
+        client_id_override=client_id_override,
+    )
+
+
+def find_flow_by_state(state: str) -> Optional[str]:
+    for flow in _ALL_FLOWS:
+        if flow.matches_state(state):
+            return flow.name
+    return None
+
+
+def clear_flow(name: str) -> None:
+    get_flow(name).clear()
+
+
+def clear_all_flows() -> None:
+    for flow in _ALL_FLOWS:
+        flow.clear()
+
+
+def register_dynamic_client(
+    *,
+    registration_endpoint: str,
+    access_token: str,
+    client_name: str,
+    redirect_uri: str,
+    scope: str,
+    contacts: Optional[list[str]] = None,
+) -> Dict[str, Any]:
+    payload = {
+        "client_name": client_name,
+        "redirect_uris": [redirect_uri],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "scope": scope,
+        "token_endpoint_auth_method": "none",
+    }
+    if contacts:
+        payload["contacts"] = contacts
+
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+
+    response = requests.post(registration_endpoint, json=payload, headers=headers, timeout=10)
+    response.raise_for_status()
+
+    try:
+        data = response.json()
+    except ValueError as exc:  # pragma: no cover - depends on remote payload
+        body = (response.text or "").strip()
+        snippet = body[:2000] + ("…" if len(body) > 2000 else "")
+        content_type = response.headers.get("Content-Type", "")
+        if "html" in content_type.lower():
+            detail = "Registration endpoint responded with HTML instead of JSON. "
+            detail += "Ensure the request is authorized and the endpoint URL is correct."
+        else:
+            detail = f"Registration endpoint returned invalid JSON ({exc})."
+        if snippet:
+            detail += f" Body preview: {snippet}"
+        raise OAuthFlowError(detail) from exc
+
+    if not isinstance(data, dict):
+        raise OAuthFlowError("Registration endpoint returned invalid payload")
+    return data

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -1,0 +1,13 @@
+from typing import Any, Optional
+
+
+def truncate(text: str, length: int) -> str:
+    return text if len(text) <= length else text[: length - 3] + "..."
+
+
+def first_query_value(raw: Any) -> Optional[str]:
+    if raw is None:
+        return None
+    if isinstance(raw, (list, tuple)):
+        return str(raw[0]) if raw else None
+    return str(raw)

--- a/justfile
+++ b/justfile
@@ -57,16 +57,19 @@ app-api-spec:
     uv run manage.py spectacular --file openapi.yaml --format openapi
     @echo "API spec saved to openapi.yaml"
 
-# app-load-base-data:
 
+app-ngrok:
+    ngrok http --url mybooks.ngrok.app 8080
 
 app-collectstatic:
    uv run manage.py tailwind build
    uv run manage.py collectstatic --no-input -i node_modules -i source.css
 
-
 streamlit:
-    streamlit run agent/agent.py
+    doppler run --config dev_agent -- streamlit run agent/agent.py --server.port 9090
+
+streamlit-ngrok:
+    ngrok http --url mybooks-agent.ngrok.app 9090
 
 ##########
 # CHECKS #

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6,34 +6,6 @@ info:
     status tracking, reviews, and recommendations.
 paths:
   /api/users/:
-    post:
-      operationId: users_create
-      description: Create a new user account
-      summary: Create user
-      tags:
-      - users
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UserRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/UserRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/UserRequest'
-        required: true
-      security:
-      - oauth2:
-        - read
-        - write
-      - tokenAuth: []
-      responses:
-        '201':
-          description: User successfully created
-        '400':
-          description: Validation error
     get:
       operationId: users_list
       description: List all users with filtering and search capabilities
@@ -103,7 +75,81 @@ paths:
       responses:
         '200':
           description: Paginated list of system users
+    post:
+      operationId: users_create
+      description: Create a new user account
+      summary: Create user
+      tags:
+      - users
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+        required: true
+      security:
+      - oauth2:
+        - read
+        - write
+      - tokenAuth: []
+      responses:
+        '201':
+          description: User successfully created
+        '400':
+          description: Validation error
   /api/users/{id}/:
+    get:
+      operationId: users_retrieve
+      description: Get detailed information about a specific user
+      summary: Get user details
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this user.
+        required: true
+      tags:
+      - users
+      security:
+      - oauth2:
+        - read
+        - write
+      - tokenAuth: []
+      responses:
+        '200':
+          description: Detailed user information
+        '404':
+          description: User not found
+    delete:
+      operationId: users_destroy
+      description: Delete a user account
+      summary: Delete user
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this user.
+        required: true
+      tags:
+      - users
+      security:
+      - oauth2:
+        - read
+        - write
+      - tokenAuth: []
+      responses:
+        '204':
+          description: User successfully deleted
+        '404':
+          description: User not found
     put:
       operationId: users_update
       description: Update user information
@@ -175,52 +221,6 @@ paths:
           description: User successfully updated
         '400':
           description: Validation error
-        '404':
-          description: User not found
-    get:
-      operationId: users_retrieve
-      description: Get detailed information about a specific user
-      summary: Get user details
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this user.
-        required: true
-      tags:
-      - users
-      security:
-      - oauth2:
-        - read
-        - write
-      - tokenAuth: []
-      responses:
-        '200':
-          description: Detailed user information
-        '404':
-          description: User not found
-    delete:
-      operationId: users_destroy
-      description: Delete a user account
-      summary: Delete user
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this user.
-        required: true
-      tags:
-      - users
-      security:
-      - oauth2:
-        - read
-        - write
-      - tokenAuth: []
-      responses:
-        '204':
-          description: User successfully deleted
         '404':
           description: User not found
   /api/groups/:
@@ -323,39 +323,6 @@ paths:
                     description: List of users in this group
           description: Users in the specified group
   /api/books/:
-    post:
-      operationId: create_book
-      description: Create a new catalog book with the required metadata (title, genre)
-        and optional tagline, description, or image. Provide the associated author
-        via the 'author_name' field; if the author does not already exist, the system
-        automatically creates one. Use this endpoint when onboarding new books into
-        the shared catalog or synchronizing titles from external feeds. Validation
-        errors report missing fields, invalid enum values, or duplicate titles when
-        combined with the same author.
-      summary: Create book
-      tags:
-      - books
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/BookRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/BookRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/BookRequest'
-        required: true
-      security:
-      - oauth2:
-        - read
-      - tokenAuth: []
-      responses:
-        '201':
-          description: Book created
-        '400':
-          description: Validation error
     get:
       operationId: list_catalog_books
       description: Browse the shared book catalog with comprehensive metadata, nested
@@ -489,7 +456,92 @@ paths:
       responses:
         '200':
           description: Paginated list of catalog books
+    post:
+      operationId: create_book
+      description: Create a new catalog book with the required metadata (title, genre)
+        and optional tagline, description, or image. Provide the associated author
+        via the 'author_name' field; if the author does not already exist, the system
+        automatically creates one. Use this endpoint when onboarding new books into
+        the shared catalog or synchronizing titles from external feeds. Validation
+        errors report missing fields, invalid enum values, or duplicate titles when
+        combined with the same author.
+      summary: Create book
+      tags:
+      - books
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BookRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/BookRequest'
+        required: true
+      security:
+      - oauth2:
+        - read
+      - tokenAuth: []
+      responses:
+        '201':
+          description: Book created
+        '400':
+          description: Validation error
   /api/books/{id}/:
+    get:
+      operationId: get_book_catalog_details
+      description: Retrieve the complete catalog record for a single book, including
+        title, tagline, description, genre, timestamps, and embedded author metadata.
+        Use this endpoint when rendering book detail pages, prefilling edit forms,
+        or validating book information during integrations. Returns 404 when the book
+        id does not exist.
+      summary: Retrieve book
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this book.
+        required: true
+      tags:
+      - books
+      security:
+      - oauth2:
+        - read
+      - tokenAuth: []
+      responses:
+        '200':
+          description: Book details returned
+        '404':
+          description: Book not found
+    delete:
+      operationId: delete_book
+      description: Delete a book from the shared catalog. This destructive action
+        cascades to user collections, reading statuses, and reviews that reference
+        the book, so coordinate with dependent teams before removal. Use it only when
+        you intend to fully retire a title from availability. Returns 404 if the book
+        cannot be found.
+      summary: Delete book
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this book.
+        required: true
+      tags:
+      - books
+      security:
+      - oauth2:
+        - read
+      - tokenAuth: []
+      responses:
+        '204':
+          description: Book deleted
+        '404':
+          description: Book not found
     put:
       operationId: update_book
       description: Replace every editable field on an existing book, including title,
@@ -569,98 +621,7 @@ paths:
           description: Validation error
         '404':
           description: Book not found
-    get:
-      operationId: get_book_catalog_details
-      description: Retrieve the complete catalog record for a single book, including
-        title, tagline, description, genre, timestamps, and embedded author metadata.
-        Use this endpoint when rendering book detail pages, prefilling edit forms,
-        or validating book information during integrations. Returns 404 when the book
-        id does not exist.
-      summary: Retrieve book
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this book.
-        required: true
-      tags:
-      - books
-      security:
-      - oauth2:
-        - read
-      - tokenAuth: []
-      responses:
-        '200':
-          description: Book details returned
-        '404':
-          description: Book not found
-    delete:
-      operationId: delete_book
-      description: Delete a book from the shared catalog. This destructive action
-        cascades to user collections, reading statuses, and reviews that reference
-        the book, so coordinate with dependent teams before removal. Use it only when
-        you intend to fully retire a title from availability. Returns 404 if the book
-        cannot be found.
-      summary: Delete book
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this book.
-        required: true
-      tags:
-      - books
-      security:
-      - oauth2:
-        - read
-      - tokenAuth: []
-      responses:
-        '204':
-          description: Book deleted
-        '404':
-          description: Book not found
   /api/user-books/:
-    post:
-      operationId: add_book_to_user_collection
-      description: Add a book to the authenticated user's personal collection with
-        initial reading status. You can either reference an existing book by its book_id
-        or create a completely new book entry if it doesn't exist in the system yet.
-        When adding an existing book, provide the book_id and desired reading_status
-        (defaults to 'want_to_read'). When creating a new book, provide complete book
-        details including title, author information, and genre. Use this tool when
-        a user wants to add a book to their personal library for tracking. The system
-        prevents duplicate entries - each user can only have one instance of each
-        book in their collection. The response includes the created UserBook relationship
-        with book details and initial status. This creates a tracking relationship
-        but doesn't modify the original book record if using an existing book. Requires
-        user authentication.
-      summary: Add a book to user's personal collection
-      tags:
-      - user-books
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UserBookRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/UserBookRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/UserBookRequest'
-      security:
-      - oauth2:
-        - write
-      - tokenAuth: []
-      responses:
-        '201':
-          description: Book successfully added to user's collection with initial reading
-            status
-        '400':
-          description: Validation error, missing required fields, or book already
-            exists in user's collection
     get:
       operationId: list_user_personal_book_collection
       description: Retrieve all books in the authenticated user's personal collection
@@ -732,31 +693,21 @@ paths:
         '200':
           description: Paginated list of books in user's personal collection with
             reading status
-  /api/user-books/{id}/:
-    put:
-      operationId: update_book_reading_status_in_collection
-      description: Update the reading status and tracking information for a book in
-        the authenticated user's collection using the userbook_id. This endpoint allows
-        changing the reading_status (want_to_read, reading, finished, dropped) and
-        automatically manages related date fields based on status transitions. When
-        status changes to 'reading', date_started is set to current time. When status
-        changes to 'finished', date_finished is set to current time. Use this tool
-        when a user progresses through reading a book or changes their intent for
-        a book in their collection. The userbook_id identifies the specific user-book
-        relationship to update. You cannot change which book this relationship points
-        to - only the user's interaction with that book. The system validates status
-        transitions and ensures dates remain consistent. Requires the complete object
-        data (PUT method). PATCH method is not supported due to technical issues -
-        use PUT for all updates. Requires user authentication and ownership of the
-        userbook relationship.
-      summary: Update reading status and tracking for book in user's collection
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this user book.
-        required: true
+    post:
+      operationId: add_book_to_user_collection
+      description: Add a book to the authenticated user's personal collection with
+        initial reading status. You can either reference an existing book by its book_id
+        or create a completely new book entry if it doesn't exist in the system yet.
+        When adding an existing book, provide the book_id and desired reading_status
+        (defaults to 'want_to_read'). When creating a new book, provide complete book
+        details including title, author information, and genre. Use this tool when
+        a user wants to add a book to their personal library for tracking. The system
+        prevents duplicate entries - each user can only have one instance of each
+        book in their collection. The response includes the created UserBook relationship
+        with book details and initial status. This creates a tracking relationship
+        but doesn't modify the original book record if using an existing book. Requires
+        user authentication.
+      summary: Add a book to user's personal collection
       tags:
       - user-books
       requestBody:
@@ -775,13 +726,13 @@ paths:
         - write
       - tokenAuth: []
       responses:
-        '200':
-          description: Book reading status successfully updated with automatic date
-            management
+        '201':
+          description: Book successfully added to user's collection with initial reading
+            status
         '400':
-          description: Validation error or invalid status transition
-        '404':
-          description: UserBook relationship not found in authenticated user's collection
+          description: Validation error, missing required fields, or book already
+            exists in user's collection
+  /api/user-books/{id}/:
     get:
       operationId: get_book_from_user_collection
       description: Retrieve comprehensive information about a specific book in the
@@ -850,38 +801,56 @@ paths:
             collection
         '404':
           description: UserBook relationship not found in authenticated user's collection
-  /api/authors/:
-    post:
-      operationId: create_author
-      description: Create a new author record that can be referenced by catalog books
-        and user collections. Provide the author's name (unique), optional biography,
-        and optional profile image to seed future book ingestion. Use this endpoint
-        when onboarding new authors into the catalog or syncing authors from external
-        feeds. Validation errors highlight duplicate names or invalid field formats.
-      summary: Create author
+    put:
+      operationId: update_book_reading_status_in_collection
+      description: Update the reading status and tracking information for a book in
+        the authenticated user's collection using the userbook_id. This endpoint allows
+        changing the reading_status (want_to_read, reading, finished, dropped) and
+        automatically manages related date fields based on status transitions. When
+        status changes to 'reading', date_started is set to current time. When status
+        changes to 'finished', date_finished is set to current time. Use this tool
+        when a user progresses through reading a book or changes their intent for
+        a book in their collection. The userbook_id identifies the specific user-book
+        relationship to update. You cannot change which book this relationship points
+        to - only the user's interaction with that book. The system validates status
+        transitions and ensures dates remain consistent. Requires the complete object
+        data (PUT method). PATCH method is not supported due to technical issues -
+        use PUT for all updates. Requires user authentication and ownership of the
+        userbook relationship.
+      summary: Update reading status and tracking for book in user's collection
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this user book.
+        required: true
       tags:
-      - authors
+      - user-books
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthorRequest'
+              $ref: '#/components/schemas/UserBookRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/AuthorRequest'
+              $ref: '#/components/schemas/UserBookRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/AuthorRequest'
-        required: true
+              $ref: '#/components/schemas/UserBookRequest'
       security:
       - oauth2:
-        - read
+        - write
       - tokenAuth: []
       responses:
-        '201':
-          description: Author created
+        '200':
+          description: Book reading status successfully updated with automatic date
+            management
         '400':
-          description: Validation error
+          description: Validation error or invalid status transition
+        '404':
+          description: UserBook relationship not found in authenticated user's collection
+  /api/authors/:
     get:
       operationId: list_authors_for_discovery
       description: Retrieve a paginated list of catalog authors with biography details,
@@ -923,7 +892,90 @@ paths:
       responses:
         '200':
           description: Paginated list of authors
+    post:
+      operationId: create_author
+      description: Create a new author record that can be referenced by catalog books
+        and user collections. Provide the author's name (unique), optional biography,
+        and optional profile image to seed future book ingestion. Use this endpoint
+        when onboarding new authors into the catalog or syncing authors from external
+        feeds. Validation errors highlight duplicate names or invalid field formats.
+      summary: Create author
+      tags:
+      - authors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthorRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AuthorRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AuthorRequest'
+        required: true
+      security:
+      - oauth2:
+        - read
+      - tokenAuth: []
+      responses:
+        '201':
+          description: Author created
+        '400':
+          description: Validation error
   /api/authors/{id}/:
+    get:
+      operationId: get_author_complete_details
+      description: Retrieve the complete profile for a specific author including biography
+        text, optional image, timestamps, and a list of books associated with that
+        author. Use this endpoint for author detail pages, edit screens, or whenever
+        you need both the author metadata and their catalog of books in a single payload.
+        Returns 404 when the author id is invalid or no longer exists.
+      summary: Retrieve author
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this author.
+        required: true
+      tags:
+      - authors
+      security:
+      - oauth2:
+        - read
+      - tokenAuth: []
+      responses:
+        '200':
+          description: Author details returned
+        '404':
+          description: Author not found
+    delete:
+      operationId: delete_author
+      description: Delete an author from the catalog. This is a destructive action
+        that cascades to all catalog books tied to the author and, by extension, to
+        user collections and reviews that depend on those books. Use this only when
+        you intentionally want to purge an author and every related record. Returns
+        404 if the author does not exist.
+      summary: Delete author
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this author.
+        required: true
+      tags:
+      - authors
+      security:
+      - oauth2:
+        - read
+      - tokenAuth: []
+      responses:
+        '204':
+          description: Author deleted
+        '404':
+          description: Author not found
     put:
       operationId: update_author
       description: Replace the entire author record with the supplied payload, including
@@ -1003,98 +1055,7 @@ paths:
           description: Validation error
         '404':
           description: Author not found
-    get:
-      operationId: get_author_complete_details
-      description: Retrieve the complete profile for a specific author including biography
-        text, optional image, timestamps, and a list of books associated with that
-        author. Use this endpoint for author detail pages, edit screens, or whenever
-        you need both the author metadata and their catalog of books in a single payload.
-        Returns 404 when the author id is invalid or no longer exists.
-      summary: Retrieve author
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this author.
-        required: true
-      tags:
-      - authors
-      security:
-      - oauth2:
-        - read
-      - tokenAuth: []
-      responses:
-        '200':
-          description: Author details returned
-        '404':
-          description: Author not found
-    delete:
-      operationId: delete_author
-      description: Delete an author from the catalog. This is a destructive action
-        that cascades to all catalog books tied to the author and, by extension, to
-        user collections and reviews that depend on those books. Use this only when
-        you intentionally want to purge an author and every related record. Returns
-        404 if the author does not exist.
-      summary: Delete author
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this author.
-        required: true
-      tags:
-      - authors
-      security:
-      - oauth2:
-        - read
-      - tokenAuth: []
-      responses:
-        '204':
-          description: Author deleted
-        '404':
-          description: Author not found
   /api/reviews/:
-    post:
-      operationId: create_user_book_review
-      description: Create a new review for a book that exists in the authenticated
-        user's personal collection. The review must include a star rating (integer
-        from 1-5) and can optionally include review text content. Users can only write
-        one review per book - attempting to create a duplicate review will result
-        in a validation error. The book being reviewed must already exist in the user's
-        collection (added via the user_books endpoints). Use this tool when a user
-        wants to rate and review a book they have read or are reading. The review
-        becomes part of the book's overall review collection and is associated with
-        both the user and the specific book. Reviews can be edited later using the
-        update endpoints. The system validates that the rating is within the 1-5 range
-        and that the user hasn't already reviewed this book. Requires user authentication
-        and the book must be in the user's collection.
-      summary: Write a new review for a book in user's collection
-      tags:
-      - reviews
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ReviewRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ReviewRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ReviewRequest'
-        required: true
-      security:
-      - oauth2:
-        - write
-      - tokenAuth: []
-      responses:
-        '201':
-          description: Review successfully created with rating and optional text
-        '400':
-          description: Validation error, invalid rating, or user has already reviewed
-            this book
     get:
       operationId: list_user_book_reviews
       description: Retrieve all book reviews that the authenticated user has written,
@@ -1154,7 +1115,110 @@ paths:
         '200':
           description: Paginated list of all reviews written by the authenticated
             user
+    post:
+      operationId: create_user_book_review
+      description: Create a new review for a book that exists in the authenticated
+        user's personal collection. The review must include a star rating (integer
+        from 1-5) and can optionally include review text content. Users can only write
+        one review per book - attempting to create a duplicate review will result
+        in a validation error. The book being reviewed must already exist in the user's
+        collection (added via the user_books endpoints). Use this tool when a user
+        wants to rate and review a book they have read or are reading. The review
+        becomes part of the book's overall review collection and is associated with
+        both the user and the specific book. Reviews can be edited later using the
+        update endpoints. The system validates that the rating is within the 1-5 range
+        and that the user hasn't already reviewed this book. Requires user authentication
+        and the book must be in the user's collection.
+      summary: Write a new review for a book in user's collection
+      tags:
+      - reviews
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReviewRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ReviewRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ReviewRequest'
+        required: true
+      security:
+      - oauth2:
+        - write
+      - tokenAuth: []
+      responses:
+        '201':
+          description: Review successfully created with rating and optional text
+        '400':
+          description: Validation error, invalid rating, or user has already reviewed
+            this book
   /api/reviews/{id}/:
+    get:
+      operationId: get_user_review_details
+      description: Retrieve complete information about a specific review written by
+        the authenticated user using the review_id. This endpoint returns the full
+        review details including the star rating, complete review text, creation and
+        last update timestamps, and comprehensive information about the book being
+        reviewed (title, author, genre, description). Use this tool when you need
+        detailed information about a specific review, such as when editing a review
+        or displaying full review content. The review_id must correspond to a review
+        written by the authenticated user - users cannot access reviews written by
+        other users through this endpoint. The response includes both the review data
+        and associated book metadata for context. Returns 404 if the review_id doesn't
+        exist or doesn't belong to the authenticated user. Requires user authentication.
+      summary: Get detailed information about a specific user review
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this review.
+        required: true
+      tags:
+      - reviews
+      security:
+      - oauth2:
+        - write
+      - tokenAuth: []
+      responses:
+        '200':
+          description: Complete review details with associated book information
+        '404':
+          description: Review not found or not owned by authenticated user
+    delete:
+      operationId: delete_user_book_review
+      description: Permanently delete a review written by the authenticated user using
+        the review_id. This operation completely removes the review from the system
+        including the rating, text content, and all associated metadata. The action
+        is irreversible - if the user wants to review the book again, they will need
+        to create a completely new review. Use this tool when a user no longer wants
+        their review to be part of the book's review collection or wants to remove
+        their opinion from the system. This does not affect the book itself or the
+        user's collection relationship to the book - it only removes the review. The
+        book remains in the user's collection with whatever reading status it had.
+        The review_id must correspond to a review owned by the authenticated user.
+        Requires user authentication and ownership of the review.
+      summary: Permanently delete a book review
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this review.
+        required: true
+      tags:
+      - reviews
+      security:
+      - oauth2:
+        - write
+      - tokenAuth: []
+      responses:
+        '204':
+          description: Review permanently deleted from the system
+        '404':
+          description: Review not found or not owned by authenticated user
     put:
       operationId: update_user_book_review
       description: Update an existing review written by the authenticated user using
@@ -1248,70 +1312,6 @@ paths:
           description: Validation error or invalid field values
         '404':
           description: Review not found or not owned by authenticated user
-    get:
-      operationId: get_user_review_details
-      description: Retrieve complete information about a specific review written by
-        the authenticated user using the review_id. This endpoint returns the full
-        review details including the star rating, complete review text, creation and
-        last update timestamps, and comprehensive information about the book being
-        reviewed (title, author, genre, description). Use this tool when you need
-        detailed information about a specific review, such as when editing a review
-        or displaying full review content. The review_id must correspond to a review
-        written by the authenticated user - users cannot access reviews written by
-        other users through this endpoint. The response includes both the review data
-        and associated book metadata for context. Returns 404 if the review_id doesn't
-        exist or doesn't belong to the authenticated user. Requires user authentication.
-      summary: Get detailed information about a specific user review
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this review.
-        required: true
-      tags:
-      - reviews
-      security:
-      - oauth2:
-        - write
-      - tokenAuth: []
-      responses:
-        '200':
-          description: Complete review details with associated book information
-        '404':
-          description: Review not found or not owned by authenticated user
-    delete:
-      operationId: delete_user_book_review
-      description: Permanently delete a review written by the authenticated user using
-        the review_id. This operation completely removes the review from the system
-        including the rating, text content, and all associated metadata. The action
-        is irreversible - if the user wants to review the book again, they will need
-        to create a completely new review. Use this tool when a user no longer wants
-        their review to be part of the book's review collection or wants to remove
-        their opinion from the system. This does not affect the book itself or the
-        user's collection relationship to the book - it only removes the review. The
-        book remains in the user's collection with whatever reading status it had.
-        The review_id must correspond to a review owned by the authenticated user.
-        Requires user authentication and ownership of the review.
-      summary: Permanently delete a book review
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this review.
-        required: true
-      tags:
-      - reviews
-      security:
-      - oauth2:
-        - write
-      - tokenAuth: []
-      responses:
-        '204':
-          description: Review permanently deleted from the system
-        '404':
-          description: Review not found or not owned by authenticated user
   /api/genres/:
     get:
       operationId: list_available_book_genres
@@ -1396,10 +1396,11 @@ paths:
         '404':
           description: Genre not found - invalid genre identifier provided
   /api/debug/headers/:
-    get:
-      operationId: debug_request_headers
+    post:
+      operationId: debug_request_headers_submit
       description: Temporary diagnostic endpoint to view incoming request headers
-        and resolved auth metadata.
+        and resolved auth metadata. Use POST to examine how headers and authentication
+        behave with bodies.
       summary: Inspect request headers and auth info
       tags:
       - debug
@@ -1413,11 +1414,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/DebugHeadersResponse'
           description: ''
-    post:
-      operationId: debug_request_headers_submit
+    get:
+      operationId: debug_request_headers
       description: Temporary diagnostic endpoint to view incoming request headers
-        and resolved auth metadata. Use POST to examine how headers and authentication
-        behave with bodies.
+        and resolved auth metadata.
       summary: Inspect request headers and auth info
       tags:
       - debug

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -127,29 +127,6 @@ paths:
           description: Detailed user information
         '404':
           description: User not found
-    delete:
-      operationId: users_destroy
-      description: Delete a user account
-      summary: Delete user
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this user.
-        required: true
-      tags:
-      - users
-      security:
-      - oauth2:
-        - read
-        - write
-      - tokenAuth: []
-      responses:
-        '204':
-          description: User successfully deleted
-        '404':
-          description: User not found
     put:
       operationId: users_update
       description: Update user information
@@ -221,6 +198,29 @@ paths:
           description: User successfully updated
         '400':
           description: Validation error
+        '404':
+          description: User not found
+    delete:
+      operationId: users_destroy
+      description: Delete a user account
+      summary: Delete user
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this user.
+        required: true
+      tags:
+      - users
+      security:
+      - oauth2:
+        - read
+        - write
+      - tokenAuth: []
+      responses:
+        '204':
+          description: User successfully deleted
         '404':
           description: User not found
   /api/groups/:
@@ -516,32 +516,6 @@ paths:
           description: Book details returned
         '404':
           description: Book not found
-    delete:
-      operationId: delete_book
-      description: Delete a book from the shared catalog. This destructive action
-        cascades to user collections, reading statuses, and reviews that reference
-        the book, so coordinate with dependent teams before removal. Use it only when
-        you intend to fully retire a title from availability. Returns 404 if the book
-        cannot be found.
-      summary: Delete book
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this book.
-        required: true
-      tags:
-      - books
-      security:
-      - oauth2:
-        - read
-      - tokenAuth: []
-      responses:
-        '204':
-          description: Book deleted
-        '404':
-          description: Book not found
     put:
       operationId: update_book
       description: Replace every editable field on an existing book, including title,
@@ -619,6 +593,32 @@ paths:
           description: Book partially updated
         '400':
           description: Validation error
+        '404':
+          description: Book not found
+    delete:
+      operationId: delete_book
+      description: Delete a book from the shared catalog. This destructive action
+        cascades to user collections, reading statuses, and reviews that reference
+        the book, so coordinate with dependent teams before removal. Use it only when
+        you intend to fully retire a title from availability. Returns 404 if the book
+        cannot be found.
+      summary: Delete book
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this book.
+        required: true
+      tags:
+      - books
+      security:
+      - oauth2:
+        - read
+      - tokenAuth: []
+      responses:
+        '204':
+          description: Book deleted
         '404':
           description: Book not found
   /api/user-books/:
@@ -767,40 +767,6 @@ paths:
             review if available
         '404':
           description: UserBook relationship not found in authenticated user's collection
-    delete:
-      operationId: remove_book_from_user_collection
-      description: Remove a book from the authenticated user's personal collection
-        using the userbook_id. This operation deletes the user-book relationship and
-        all associated tracking data (reading status, dates) but does NOT delete the
-        book itself from the system - other users can still have this book in their
-        collections and the book remains available for browsing and future additions.
-        Use this tool when a user wants to completely remove a book from their personal
-        library and stop tracking it. This action also removes any review the user
-        has written for this book, as reviews are tied to the user-book relationship.
-        The userbook_id identifies the specific relationship to delete. This is irreversible
-        - if the user wants the book back in their collection, they'll need to add
-        it again with a fresh tracking relationship. Requires user authentication
-        and ownership of the userbook relationship.
-      summary: Remove book from user's personal collection
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this user book.
-        required: true
-      tags:
-      - user-books
-      security:
-      - oauth2:
-        - write
-      - tokenAuth: []
-      responses:
-        '204':
-          description: Book and all tracking data successfully removed from user's
-            collection
-        '404':
-          description: UserBook relationship not found in authenticated user's collection
     put:
       operationId: update_book_reading_status_in_collection
       description: Update the reading status and tracking information for a book in
@@ -848,6 +814,40 @@ paths:
             management
         '400':
           description: Validation error or invalid status transition
+        '404':
+          description: UserBook relationship not found in authenticated user's collection
+    delete:
+      operationId: remove_book_from_user_collection
+      description: Remove a book from the authenticated user's personal collection
+        using the userbook_id. This operation deletes the user-book relationship and
+        all associated tracking data (reading status, dates) but does NOT delete the
+        book itself from the system - other users can still have this book in their
+        collections and the book remains available for browsing and future additions.
+        Use this tool when a user wants to completely remove a book from their personal
+        library and stop tracking it. This action also removes any review the user
+        has written for this book, as reviews are tied to the user-book relationship.
+        The userbook_id identifies the specific relationship to delete. This is irreversible
+        - if the user wants the book back in their collection, they'll need to add
+        it again with a fresh tracking relationship. Requires user authentication
+        and ownership of the userbook relationship.
+      summary: Remove book from user's personal collection
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this user book.
+        required: true
+      tags:
+      - user-books
+      security:
+      - oauth2:
+        - write
+      - tokenAuth: []
+      responses:
+        '204':
+          description: Book and all tracking data successfully removed from user's
+            collection
         '404':
           description: UserBook relationship not found in authenticated user's collection
   /api/authors/:
@@ -950,32 +950,6 @@ paths:
           description: Author details returned
         '404':
           description: Author not found
-    delete:
-      operationId: delete_author
-      description: Delete an author from the catalog. This is a destructive action
-        that cascades to all catalog books tied to the author and, by extension, to
-        user collections and reviews that depend on those books. Use this only when
-        you intentionally want to purge an author and every related record. Returns
-        404 if the author does not exist.
-      summary: Delete author
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this author.
-        required: true
-      tags:
-      - authors
-      security:
-      - oauth2:
-        - read
-      - tokenAuth: []
-      responses:
-        '204':
-          description: Author deleted
-        '404':
-          description: Author not found
     put:
       operationId: update_author
       description: Replace the entire author record with the supplied payload, including
@@ -1053,6 +1027,32 @@ paths:
           description: Author partially updated
         '400':
           description: Validation error
+        '404':
+          description: Author not found
+    delete:
+      operationId: delete_author
+      description: Delete an author from the catalog. This is a destructive action
+        that cascades to all catalog books tied to the author and, by extension, to
+        user collections and reviews that depend on those books. Use this only when
+        you intentionally want to purge an author and every related record. Returns
+        404 if the author does not exist.
+      summary: Delete author
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this author.
+        required: true
+      tags:
+      - authors
+      security:
+      - oauth2:
+        - read
+      - tokenAuth: []
+      responses:
+        '204':
+          description: Author deleted
         '404':
           description: Author not found
   /api/reviews/:
@@ -1187,38 +1187,6 @@ paths:
           description: Complete review details with associated book information
         '404':
           description: Review not found or not owned by authenticated user
-    delete:
-      operationId: delete_user_book_review
-      description: Permanently delete a review written by the authenticated user using
-        the review_id. This operation completely removes the review from the system
-        including the rating, text content, and all associated metadata. The action
-        is irreversible - if the user wants to review the book again, they will need
-        to create a completely new review. Use this tool when a user no longer wants
-        their review to be part of the book's review collection or wants to remove
-        their opinion from the system. This does not affect the book itself or the
-        user's collection relationship to the book - it only removes the review. The
-        book remains in the user's collection with whatever reading status it had.
-        The review_id must correspond to a review owned by the authenticated user.
-        Requires user authentication and ownership of the review.
-      summary: Permanently delete a book review
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this review.
-        required: true
-      tags:
-      - reviews
-      security:
-      - oauth2:
-        - write
-      - tokenAuth: []
-      responses:
-        '204':
-          description: Review permanently deleted from the system
-        '404':
-          description: Review not found or not owned by authenticated user
     put:
       operationId: update_user_book_review
       description: Update an existing review written by the authenticated user using
@@ -1310,6 +1278,38 @@ paths:
             management
         '400':
           description: Validation error or invalid field values
+        '404':
+          description: Review not found or not owned by authenticated user
+    delete:
+      operationId: delete_user_book_review
+      description: Permanently delete a review written by the authenticated user using
+        the review_id. This operation completely removes the review from the system
+        including the rating, text content, and all associated metadata. The action
+        is irreversible - if the user wants to review the book again, they will need
+        to create a completely new review. Use this tool when a user no longer wants
+        their review to be part of the book's review collection or wants to remove
+        their opinion from the system. This does not affect the book itself or the
+        user's collection relationship to the book - it only removes the review. The
+        book remains in the user's collection with whatever reading status it had.
+        The review_id must correspond to a review owned by the authenticated user.
+        Requires user authentication and ownership of the review.
+      summary: Permanently delete a book review
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this review.
+        required: true
+      tags:
+      - reviews
+      security:
+      - oauth2:
+        - write
+      - tokenAuth: []
+      responses:
+        '204':
+          description: Review permanently deleted from the system
         '404':
           description: Review not found or not owned by authenticated user
   /api/genres/:
@@ -1986,9 +1986,9 @@ components:
       type: oauth2
       flows:
         authorizationCode:
-          authorizationUrl: https://hypolimnial-wai-modularly.ngrok-free.dev/oauth/authorize/
-          tokenUrl: https://hypolimnial-wai-modularly.ngrok-free.dev/oauth/token/
-          refreshUrl: https://hypolimnial-wai-modularly.ngrok-free.dev/oauth/token/
+          authorizationUrl: https://mybooks.ngrok.app/oauth/authorize/
+          tokenUrl: https://mybooks.ngrok.app/oauth/token/
+          refreshUrl: https://mybooks.ngrok.app/oauth/token/
           scopes:
             read: Read scope
             write: Write scope
@@ -1998,4 +1998,4 @@ components:
       name: Authorization
       description: Token-based authentication with required prefix "Token"
 servers:
-- url: https://hypolimnial-wai-modularly.ngrok-free.dev
+- url: https://mybooks.ngrok.app

--- a/templates/oauth2_provider/authorize.html
+++ b/templates/oauth2_provider/authorize.html
@@ -1,22 +1,22 @@
 {% extends "base.html" %}
-{# AIDEV-NOTE: DOT authorize override mirrors default flow with Flowbite card styling and base layout. #}
+{# AIDEV-NOTE: Authorization view styled to mirror Sentry MCP inspector for richer OAuth consent UX. #}
 {% load i18n %}
 
 {% block title %}{% trans "Authorize Application" %}{% endblock %}
-{% block body_classes %}bg-gray-50 dark:bg-gray-900{% endblock %}
+{% block body_classes %}bg-slate-950 text-slate-100{% endblock %}
 
 {% block body %}
-    <div class="min-h-screen flex mt-24 justify-center py-16 px-4">
-        <div class="w-full max-w-lg">
+    <div class="min-h-screen flex items-center justify-center py-16 px-4 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
+        <div class="w-full max-w-4xl">
             {% if not error %}
-                <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-lg rounded-2xl p-8">
-                    <form id="authorizationForm" method="post" class="space-y-6">
-                        <div>
-                            <h1 class="text-2xl font-semibold text-gray-900 dark:text-white">
-                                {% blocktrans with app_name=application.name %}Authorize {{ app_name }}?{% endblocktrans %}
+                <div class="rounded-3xl border border-slate-700/70 bg-slate-900/70 shadow-xl backdrop-blur">
+                    <form id="authorizationForm" method="post" class="p-8 sm:p-12 space-y-10">
+                        <div class="space-y-4">
+                            <h1 class="text-3xl font-semibold text-white sm:text-4xl">
+                                {% blocktrans with app_name=application.name %}{{ app_name }} is requesting access{% endblocktrans %}
                             </h1>
-                            <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
-                                {% trans "Application requires the following permissions" %}
+                            <p class="text-base text-slate-300">
+                                {% trans "Review the details below. Approving will redirect you back to the requesting application." %}
                             </p>
                         </div>
 
@@ -27,45 +27,76 @@
                             {% endif %}
                         {% endfor %}
 
-                        {% if scopes_descriptions %}
-                            <ul class="space-y-2 ps-5 text-sm text-gray-700 dark:text-gray-200 list-disc">
-                                {% for scope in scopes_descriptions %}
-                                    <li>{{ scope }}</li>
-                                {% endfor %}
-                            </ul>
-                        {% endif %}
+                        <div class="grid gap-6 sm:grid-cols-2 text-sm text-slate-200">
+                            <div class="rounded-2xl border border-slate-700/60 bg-slate-900/60 p-6 sm:col-span-2">
+                                <p class="text-xs uppercase tracking-wider text-slate-400">{% trans "Name" %}</p>
+                                <p class="mt-2 text-lg font-medium text-white break-words">{{ application.name }}</p>
+                            </div>
+                            <div class="rounded-2xl border border-slate-700/60 bg-slate-900/60 p-6 sm:col-span-2">
+                                <p class="text-xs uppercase tracking-wider text-slate-400">{% trans "Redirect URIs" %}</p>
+                                <div class="mt-2 text-base text-slate-200/90">
+                                    {{ application.redirect_uris|default:_("No redirect URIs configured") }}
+                                </div>
+                            </div>
+                            <div class="rounded-2xl border border-slate-700/60 bg-slate-900/60 p-6 sm:col-span-2">
+                                <p class="text-xs uppercase tracking-wider text-slate-400">{% trans "Client ID" %}</p>
+                                <p class="mt-2 font-mono text-base text-indigo-300">{{ application.client_id }}</p>
+                            </div>
+                        </div>
+
+                        <div class="space-y-4">
+                            <h2 class="text-xl font-semibold text-white">{% trans "Permissions" %}</h2>
+                            {% if scopes_descriptions %}
+                                <div class="space-y-3">
+                                    {% for scope in scopes_descriptions %}
+                                        <div class="flex items-start gap-3 rounded-2xl border border-indigo-500/40 bg-indigo-500/10 px-4 py-3">
+                                            <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/20">
+                                                <svg class="h-4 w-4 text-emerald-300" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                                    <path fill-rule="evenodd" d="M16.704 5.29a1 1 0 0 1 .006 1.414l-7.001 7a1 1 0 0 1-1.414 0l-3.001-3a1 1 0 0 1 1.414-1.414l2.294 2.293 6.294-6.293a1 1 0 0 1 1.408 0Z" clip-rule="evenodd" />
+                                                </svg>
+                                            </span>
+                                            <p class="text-sm text-slate-100">{{ scope }}</p>
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                            {% else %}
+                                <p class="text-sm text-slate-300">
+                                    {% trans "This application is not requesting any additional permissions." %}
+                                </p>
+                            {% endif %}
+                        </div>
 
                         {% if form.errors or form.non_field_errors %}
-                            <div class="text-sm text-red-600 dark:text-red-400 space-y-1">
+                            <div class="rounded-2xl border border-red-500/60 bg-red-500/10 p-4 text-sm text-red-300">
                                 {{ form.errors }}
                                 {{ form.non_field_errors }}
                             </div>
                         {% endif %}
 
-                        <div class="flex flex-col sm:flex-row sm:justify-end gap-3 pt-4">
+                        <div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
                             <input
                                 type="submit"
-                                class="w-full sm:w-auto inline-flex justify-center items-center rounded-lg border border-gray-300 bg-white px-5 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:border-gray-600 dark:bg-transparent dark:text-gray-200 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
+                                class="w-full sm:w-auto inline-flex justify-center rounded-xl border border-slate-700/70 bg-transparent px-6 py-2.5 text-sm font-medium text-slate-200 transition hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500/80"
                                 value="{% trans 'Cancel' %}"
                             />
                             <input
                                 type="submit"
                                 name="allow"
-                                class="w-full sm:w-auto inline-flex justify-center items-center rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-4 focus:ring-blue-300 dark:bg-blue-500 dark:hover:bg-blue-600 dark:focus:ring-blue-800 hover:cursor-pointer"
+                                class="w-full sm:w-auto inline-flex justify-center rounded-xl bg-indigo-500 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 hover:cursor-pointer"
                                 value="{% trans 'Authorize' %}"
                             />
                         </div>
                     </form>
                 </div>
             {% else %}
-                <div class="bg-white dark:bg-gray-800 border border-red-200 dark:border-red-800 shadow-lg rounded-2xl p-8">
-                    <h1 class="text-2xl font-semibold text-red-700 dark:text-red-400 mb-2">
+                <div class="rounded-3xl border border-red-500/60 bg-red-900/40 shadow-xl backdrop-blur p-10">
+                    <h1 class="text-2xl font-semibold text-red-200 mb-2">
                         {% trans "Authorization Error" %}
                     </h1>
-                    <p class="text-sm text-gray-700 dark:text-gray-200">
+                    <p class="text-sm text-red-100">
                         <span class="font-medium">{% trans "Error" %}:</span> {{ error.error }}
                     </p>
-                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">{{ error.description }}</p>
+                    <p class="mt-2 text-sm text-red-100/80">{{ error.description }}</p>
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
* Build a Streamlit-based MCP agent (agent/agent.py) that handles login, dynamic client registration, authorization, chat UI, and MCP tool surfacing
* Persist agent state via the new AppDataStore, including login/authorization tokens and saved registration payloads (agent/app_data_store.py, .app_data.json)
* Add OAuth utility modules for discovery, PKCE generation, dynamic client registration, and token exchanges (agent/oauth.py, agent/oauth_flow.py, agent/utils.py)
* Upgrade the OAuth authorize template to a dark Sentry-inspired layout with richer client metadata and permission styling (templates/oauth2_provider/authorize.html)
* Refresh supporting project config/docs (openapi spec, justfile, oauth views, launch config, .gitignore) for the new workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Streamlined OAuth sign-in, dynamic client registration, and app authorization within the app, with clearer error messaging.
  - Expanded API: create/retrieve users, books, authors, reviews, user-book relations, and genres; added debug headers submit endpoint.
  - Streamlit now runs on port 9090; added ngrok commands to expose the app.

- Style
  - Redesigned OAuth authorization page with improved layout, accessibility, and scope presentation.

- Security
  - Removed sensitive credentials from the repository; API supports auth via Bearer tokens.

- Chores
  - Updated ignore rules and launch configurations; refreshed server and OAuth domain URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->